### PR TITLE
Implement public-api

### DIFF
--- a/async_addition/public-api/Dockerfile
+++ b/async_addition/public-api/Dockerfile
@@ -1,5 +1,9 @@
-FROM alpine:latest
+FROM python:3.8
 
-# TODO: Implement Public API
+WORKDIR /app
 
-ENTRYPOINT ["tail", "-f", "/dev/null"]
+COPY . /app
+
+RUN pip install -r requirements.txt
+
+CMD ["/usr/local/bin/python", "/app/api.py"]

--- a/async_addition/public-api/api.py
+++ b/async_addition/public-api/api.py
@@ -1,0 +1,66 @@
+from fastapi import FastAPI, HTTPException
+import httpx
+import uuid
+import uvicorn
+import threading
+from typing import Union
+from consumer import start_kafka_consumer, message_cache, thread_lock
+
+
+app = FastAPI(title="Public API for Async Addition")
+
+
+# FastAPI endpoint to receive two numbers and forward them to the internal API
+@app.post("/add")
+async def add_numbers(numberOne: Union[int, float], numberTwo: Union[int, float]):
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post("http://localhost:3000/add", json={"numberOne": numberOne, "numberTwo": numberTwo})
+            response.raise_for_status()
+            uuid = response.json()['asyncId']
+            return {"asyncId": uuid}
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=503, detail="Unable to connect to addition-service")
+    except httpx.HTTPStatusError as e:
+        # Handle specific HTTP errors (e.g., 4xx, 5xx responses)
+        raise HTTPException(status_code=e.response.status_code, detail=str(e))
+    except Exception as e:
+        # Catch other exceptions and handle them
+        raise HTTPException(
+            status_code=500, detail="An unexpected error occurred")
+
+
+# Used to validate that the input string is an UUID
+def is_valid_uuid(uuid_to_test, version=4):
+    try:
+        uuid_obj = uuid.UUID(uuid_to_test, version=version)
+        return str(uuid_obj) == uuid_to_test
+    except ValueError:
+        return False
+
+# FastAPI endpoint to get the result using UUID
+
+
+@app.get("/result/{uuid}")
+async def get_result(uuid: str):
+    if not is_valid_uuid(uuid):
+        raise HTTPException(status_code=400, detail="Invalid UUID format")
+
+    with thread_lock:
+        cached_result = message_cache.get(uuid)
+        if cached_result:
+            print("Found value stored in cache")
+            return {"result": cached_result}
+
+    raise HTTPException(status_code=404, detail="Result not found")
+
+
+def run_kafka_consumer_thread():
+    kafka_thread = threading.Thread(target=start_kafka_consumer)
+    kafka_thread.start()
+
+
+if __name__ == "__main__":
+    run_kafka_consumer_thread()
+    uvicorn.run(app, host="0.0.0.0", port=8443, log_level="debug")

--- a/async_addition/public-api/components.py
+++ b/async_addition/public-api/components.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class CalculationRequest(BaseModel):
+    numberOne: float
+    numberTwo: float
+
+
+class CalculationResult(BaseModel):
+    numberOne: float
+    numberTwo: float
+    result: float
+
+
+class CalculationResponse(BaseModel):
+    asyncId: str
+    result: Optional[CalculationResult] = None
+
+
+class CombinedResponse(BaseModel):
+    asyncId: str
+    numberOne: float
+    numberTwo: float
+    result: float

--- a/async_addition/public-api/consumer.py
+++ b/async_addition/public-api/consumer.py
@@ -1,0 +1,51 @@
+import json
+import threading
+import os
+import traceback
+from kafka.errors import NoBrokersAvailable
+from kafka import KafkaConsumer
+
+# Cache dictionary. Ideally we would want to use a database for storing this information
+message_cache = {}
+thread_lock = threading.Lock()
+
+
+# Creates the Kafka consumer
+def create_kafka_consumer():
+    try:
+        print("Attempting to initialize Kafka consumer")
+        consumer = KafkaConsumer(
+            'addition-service.results',
+            group_id='public-api-group',
+            bootstrap_servers=['localhost:9092'],
+            value_deserializer=lambda m: json.loads(m.decode('utf-8')),
+            auto_offset_reset='earliest',
+            api_version=(3, 6, 0)
+        )
+        print("Kafka Consumer is connected and ready.")
+        return consumer
+    except NoBrokersAvailable as e:
+        print(f"An exception occurred: {type(e).__name__}")
+        print(f"Error message: {str(e)}")
+        traceback.print_exc()
+        os._exit(1)  # Sort of hacky way to exit; ungraceful shutdown
+
+# Query Kafka for new messages and stores them with their UUID and result in the cache
+
+
+def consume_messages(consumer):
+    for message in consumer:
+        print(message)
+        uuid = message.value['asyncId']
+        result = message.value['result']
+
+        # Threadsafe caching
+        with thread_lock:
+            message_cache[uuid] = result
+        print(f"Stored result for UUID {uuid}: {result}")
+
+
+def start_kafka_consumer():
+    # Kafka consumer setup and message processing loop
+    consumer = create_kafka_consumer()
+    consume_messages(consumer)

--- a/async_addition/public-api/requirements.txt
+++ b/async_addition/public-api/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn 
 httpx 
 kafka-python
+pydantic

--- a/async_addition/public-api/requirements.txt
+++ b/async_addition/public-api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi 
+uvicorn 
+httpx 
+kafka-python


### PR DESCRIPTION
Hej! 

Här är min implementation av public-api. För att interagera med APIt så kan ni gå in på http://localhost:8443/docs där ni kan läsa API-dokumentationen samt generera requests till de olika endpointerna via SwaggerEditor.

Det finns några problem med implementationen:

Det största är att jag skriver UUID och resultatet till en Python-dictionary och använder det som en cache. Denna kommer naturligtvis tillslut bli full och använda upp allt minne. En bättre lösning är att ha en extern databas dit man skriver resultaten. Då får man även fördelen att flera noder skulle kunna läsa ifrån den. Dock kan jag inte göra det p.g.a begränsingen att jag ej fick ändra docker-compose filen.

Ett annat problem är att om vi inte lyckas ansluta till Kafka consumer så kommer os._exit(1) köras, vilket avslutar applikationen på samma sätt som kill -9. Detta gör att resurser o.s.v inte frias upp, vilket inte är ett problem i detta fall då vi ej har något som är persistent. Det vore bättre att skicka en signal till huvudtråden och få den att avsluta graciöst och släppa alla resurser.

Ser fram emot att diskutera detta ytterligare med er.